### PR TITLE
feat: add the logic for loading storefront context

### DIFF
--- a/client-app/App.vue
+++ b/client-app/App.vue
@@ -11,7 +11,10 @@
 <script setup lang="ts">
 import { Header, Footer } from "./shared/layout";
 import { useCart } from "@/shared/cart";
+import { useContext } from "@/shared/context";
 
 const { loadMyCart } = useCart();
+const { loadContext } = useContext();
 loadMyCart();
+loadContext();
 </script>

--- a/client-app/shared/context/composables/index.ts
+++ b/client-app/shared/context/composables/index.ts
@@ -1,0 +1,1 @@
+export { default as useContext } from "./useContext";

--- a/client-app/shared/context/composables/useContext.ts
+++ b/client-app/shared/context/composables/useContext.ts
@@ -1,0 +1,20 @@
+import { computed, Ref, ref } from "vue";
+import { ThemeContext } from "../types";
+
+const themeContext: Ref<ThemeContext> = ref({});
+
+export default () => {
+  async function loadContext() {
+    const response = await fetch("/storefrontapi/theme/context", {
+      method: "GET",
+      headers: {
+        Accept: "text/plain",
+      },
+    });
+    themeContext.value = await response.json();
+  }
+  return {
+    loadContext,
+    themeContext: computed(() => themeContext.value),
+  };
+};

--- a/client-app/shared/context/index.ts
+++ b/client-app/shared/context/index.ts
@@ -1,0 +1,2 @@
+export * from "./composables";
+export * from "./types";

--- a/client-app/shared/context/types/index.ts
+++ b/client-app/shared/context/types/index.ts
@@ -1,0 +1,13 @@
+export type ThemeContext = {
+  baseUrl?: string;
+  storeId?: string;
+  storeName?: string;
+  language?: string;
+  availLanguages?: string[];
+  catalogId?: string;
+  currency?: string;
+  availCurrencies?: string[];
+  userId?: string;
+  userName?: string;
+  settings?: { key: string; value: unknown }[];
+};


### PR DESCRIPTION
https://virtocommerce.atlassian.net/browse/ST-393
usage 
```js
import { useContext } from "@/shared/context";
const { themeContext } = useContext();
....
themeContext.catalogId
```
Download artifact URL: https://vc3prerelease.blob.core.windows.net/packages/client-app-0.0.1-pr-23-f057be46.zip